### PR TITLE
Feature/27, 32 타겟웹사이트, 프로그램 재배치, jsonConveter작업 개선

### DIFF
--- a/app/src/main/java/org/edb/main/EDBPlugin.java
+++ b/app/src/main/java/org/edb/main/EDBPlugin.java
@@ -16,7 +16,8 @@ public abstract class EDBPlugin {
 
     protected Date startDate;
     protected Date endDate;
-    protected int pulginIdx;
+
+
     protected boolean isRunning;
     protected String fxPath;
     protected String androidPath;
@@ -27,6 +28,8 @@ public abstract class EDBPlugin {
     public abstract void renewTrackingTarget();
     public abstract void checkForLogics();
 
+    public abstract int getPluginIdx();
+
     public  void extractConfigs(PluginConfigConverter pluginConfigConverter){
         pluginConfigConverter.setSchedule(startDate, endDate);
         pluginConfigConverter.setTargetPrograms(targetPrograms);
@@ -35,6 +38,7 @@ public abstract class EDBPlugin {
             entry.getValue().extractConfig(pluginConfigConverter);
         }
     }
+
 
     public void decodeConfigs(PluginModel data, PluginConfigConverter pluginConfigConverter){
         Date from = new Date();
@@ -56,9 +60,8 @@ public abstract class EDBPlugin {
         targetWebsites = pluginConfigConverter.getTargetWebsites();
         Map<String,Map<String,String>> strConfigsMap = pluginConfigConverter.getPluginConfigMap();
 
-//        TODO EDBPlugin 에러수정
         for (Map.Entry<String, Map<String,String>> entry : strConfigsMap.entrySet()) {
-            pluginConfigs.get(entry.getKey()).decode(entry.getValue());
+            pluginConfigs.get(entry.getKey()).decodeFromMap(entry.getValue());
         }
     }
 
@@ -83,7 +86,7 @@ public abstract class EDBPlugin {
         targetWebsites.remove(targetWebsite.getTargetURL());
     }
 
-    public void applySingleConfig(String configName, String config){
-        pluginConfigs.get(configName).addSingleConfig(config);
+    public void applySingleConfig(String configName, String attributeName, String config){
+        pluginConfigs.get(configName).addSingleConfig(attributeName,config);
     }
 }

--- a/app/src/main/java/org/edb/main/EDBPlugin.java
+++ b/app/src/main/java/org/edb/main/EDBPlugin.java
@@ -11,6 +11,9 @@ import java.util.Map;
 
 public abstract class EDBPlugin {
     protected Map<String,PluginConfig> pluginConfigs;
+    protected Map<String, TargetProgram> targetPrograms;
+    protected Map<String, TargetWebsite> targetWebsites;
+
     protected Date startDate;
     protected Date endDate;
     protected int pulginIdx;
@@ -26,6 +29,8 @@ public abstract class EDBPlugin {
 
     public  void extractConfigs(PluginConfigConverter pluginConfigConverter){
         pluginConfigConverter.setSchedule(startDate, endDate);
+        pluginConfigConverter.setTargetPrograms(targetPrograms);
+        pluginConfigConverter.setTargetWebsites(targetWebsites);
         for (Map.Entry<String, PluginConfig> entry : pluginConfigs.entrySet()){
             entry.getValue().extractConfig(pluginConfigConverter);
         }
@@ -46,7 +51,9 @@ public abstract class EDBPlugin {
         this.startDate = from;
         this.endDate = to;
 
-        pluginConfigConverter.convertStrConfigToMap(data.getConfiguration());
+        pluginConfigConverter.convertStrConfigs(data.getConfiguration());
+        targetPrograms = pluginConfigConverter.getTargetPrograms();
+        targetWebsites = pluginConfigConverter.getTargetWebsites();
         Map<String,String> strConfigsMap = pluginConfigConverter.getPluginConfigMap();
 
         for (Map.Entry<String, String> entry : strConfigsMap.entrySet()) {
@@ -60,19 +67,19 @@ public abstract class EDBPlugin {
     }
 
     public void addTargetProgram(TargetProgram targetProgram) {
-        pluginConfigs.get("TargetProgram").addSingleConfig(targetProgram.toString());
+        targetPrograms.put(targetProgram.getTargetName(),targetProgram);
     }
 
     public void removeTargetProgram(TargetProgram targetProgram) {
-        pluginConfigs.get("TargetProgram").removeSingleConfig(targetProgram.toString());
-    }
-
-    public void removeTargetWebsite(TargetWebsite targetWebsite) {
-        pluginConfigs.get("TargetWebsite").removeSingleConfig(targetWebsite.toString());
+        targetPrograms.remove(targetProgram.getTargetName());
     }
 
     public void addTargetWebsite(TargetWebsite targetWebsite) {
-        pluginConfigs.get("TargetWebsite").addSingleConfig(targetWebsite.toString());
+        targetWebsites.put(targetWebsite.getTargetURL(),targetWebsite);
+    }
+
+    public void removeTargetWebsite(TargetWebsite targetWebsite) {
+        targetWebsites.remove(targetWebsite.getTargetURL());
     }
 
     public void applySingleConfig(String configName, String config){

--- a/app/src/main/java/org/edb/main/EDBPlugin.java
+++ b/app/src/main/java/org/edb/main/EDBPlugin.java
@@ -54,9 +54,10 @@ public abstract class EDBPlugin {
         pluginConfigConverter.convertStrConfigs(data.getConfiguration());
         targetPrograms = pluginConfigConverter.getTargetPrograms();
         targetWebsites = pluginConfigConverter.getTargetWebsites();
-        Map<String,String> strConfigsMap = pluginConfigConverter.getPluginConfigMap();
+        Map<String,Map<String,String>> strConfigsMap = pluginConfigConverter.getPluginConfigMap();
 
-        for (Map.Entry<String, String> entry : strConfigsMap.entrySet()) {
+//        TODO EDBPlugin 에러수정
+        for (Map.Entry<String, Map<String,String>> entry : strConfigsMap.entrySet()) {
             pluginConfigs.get(entry.getKey()).decode(entry.getValue());
         }
     }

--- a/app/src/main/java/org/edb/main/PluginConfig.java
+++ b/app/src/main/java/org/edb/main/PluginConfig.java
@@ -3,9 +3,9 @@ package org.edb.main;
 import java.util.Map;
 
 public abstract class PluginConfig {
-    public abstract void addSingleConfig(String singleConfig);
+    public abstract void addSingleConfig(String attributeName, String attributeValue);
 
-    public abstract void decode(Map<String, String> decodeConfig);
+    public abstract void decodeFromMap(Map<String, String> decodeConfig);
 
     public abstract void removeSingleConfig(String singleConfig);
 

--- a/app/src/main/java/org/edb/main/PluginConfig.java
+++ b/app/src/main/java/org/edb/main/PluginConfig.java
@@ -1,9 +1,11 @@
 package org.edb.main;
 
+import java.util.Map;
+
 public abstract class PluginConfig {
     public abstract void addSingleConfig(String singleConfig);
 
-    public abstract void decode(String decodeConfig);
+    public abstract void decode(Map<String, String> decodeConfig);
 
     public abstract void removeSingleConfig(String singleConfig);
 

--- a/app/src/main/java/org/edb/main/PluginConfigConverter.java
+++ b/app/src/main/java/org/edb/main/PluginConfigConverter.java
@@ -1,11 +1,16 @@
 package org.edb.main;
 
+import org.edb.main.model.TargetProgram;
+import org.edb.main.model.TargetWebsite;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class PluginConfigConverter {
     protected Map<String,String> pluginConfigs;
+    protected Map<String,TargetProgram> targetPrograms;
+    protected Map<String,TargetWebsite> targetWebsites;
     protected Date startDate;
     protected Date endDate;
 
@@ -22,11 +27,21 @@ public abstract class PluginConfigConverter {
         this.endDate = endDate;
     }
 
-    protected abstract void convert();
+    protected abstract void convertForPost();
 
-    public abstract void convertStrConfigToMap(String configuration) ;
+    public abstract void convertStrConfigs(String configuration) ;
 
     public Map<String,String> getPluginConfigMap(){
         return pluginConfigs;
     }
+
+//    TODO setTargetPrograms 구현
+    public abstract void setTargetPrograms(Map<String, TargetProgram> targetPrograms);
+
+//    TODO setTargetWebsites 구현
+    public abstract void setTargetWebsites(Map<String, TargetWebsite> targetWebsites);
+
+    public abstract Map<String, TargetProgram> getTargetPrograms();
+
+    public abstract Map<String, TargetWebsite> getTargetWebsites();
 }

--- a/app/src/main/java/org/edb/main/PluginConfigConverter.java
+++ b/app/src/main/java/org/edb/main/PluginConfigConverter.java
@@ -8,18 +8,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class PluginConfigConverter {
-    protected Map<String,String> pluginConfigs;
+    protected Map<String,Map<String,String>> pluginConfigs;
     protected Map<String,TargetProgram> targetPrograms;
     protected Map<String,TargetWebsite> targetWebsites;
     protected Date startDate;
     protected Date endDate;
 
     protected PluginConfigConverter(){
-        pluginConfigs = new HashMap<String,String>();
+        pluginConfigs = new HashMap<String,Map<String,String>>();
     }
 
-    public void addSingleConfig(String configName, String configStr){
-        pluginConfigs.put(configName,configStr);
+    public void addSingleConfig(String configName, Map<String,String> configAttributes){
+        pluginConfigs.put(configName,configAttributes);
     }
 
     public void setSchedule(Date startDate, Date endDate){
@@ -27,18 +27,16 @@ public abstract class PluginConfigConverter {
         this.endDate = endDate;
     }
 
-    protected abstract void convertForPost();
+    protected abstract void makeFormatForPost();
 
     public abstract void convertStrConfigs(String configuration) ;
 
-    public Map<String,String> getPluginConfigMap(){
+    public Map<String,Map<String,String>> getPluginConfigMap(){
         return pluginConfigs;
     }
 
-//    TODO setTargetPrograms 구현
     public abstract void setTargetPrograms(Map<String, TargetProgram> targetPrograms);
 
-//    TODO setTargetWebsites 구현
     public abstract void setTargetWebsites(Map<String, TargetWebsite> targetWebsites);
 
     public abstract Map<String, TargetProgram> getTargetPrograms();

--- a/app/src/main/java/org/edb/main/ServerRequester.java
+++ b/app/src/main/java/org/edb/main/ServerRequester.java
@@ -13,7 +13,7 @@ public interface ServerRequester {
     public void requestUserPlugins();//load user plugin list
     public void requestAvailablePlugins();//load available plugin list
     public void requestPluginDetails(int pluginIdx);
-    public void requestPostUserPlugin(int pluginIdx, JsonConverter jsonConverter);
+    public void requestPostUserPlugin(int pluginIdx);
 
     public void setServerResponseHandler(ServerResponseHandler serverResponseHandler);
 

--- a/app/src/main/java/org/edb/main/UI/PluginConfigUIController.java
+++ b/app/src/main/java/org/edb/main/UI/PluginConfigUIController.java
@@ -79,7 +79,7 @@ public class PluginConfigUIController implements Initializable {
         targetWebsiteTableView.setItems(fxTargetWebsiteObservableList);
     }
 
-    //TODO pluginConfigUI 화면불러오기
+    //TODO pluginConfigUI 화면불러오기, 구체적인 pluginConfigUI가 정의되지 않았기에 아직 불가능.
     public void loadPluginConfigRequested(){
 //        시간, 잠금대상, 잠금웹사이트 config를 받아와서, 이 ui에 뿌리고
 //        EDBPlugin에서 PluginConfigUI불러와서 configArea에 달아주고
@@ -120,9 +120,8 @@ public class PluginConfigUIController implements Initializable {
         plugin.removeTargetWebsite(selectedItem.convertToTargetWebsite());
     }
 
-    //TODO 서버에 반영하기
     public void applyToServer(){
-//        edbPlugin변환해서 서버리퀘스트로 보낸다
+        uiEventHandler.onPostUserPlugin(plugin.getPluginIdx());
     }
 
     public void schedulePlugin(){
@@ -142,7 +141,6 @@ public class PluginConfigUIController implements Initializable {
         modifyScheduleBtn.setVisible(true);
         scheduledTimeLbl.setVisible(true);
 
-        //TODO 시간 출력 포맷 확인
         String scheduledTime = startDate.toString()+ "부터 " + endDate.toString()+"까지";
         scheduledTimeLbl.setText(scheduledTime);
     }

--- a/app/src/main/java/org/edb/main/UIEventHandler.java
+++ b/app/src/main/java/org/edb/main/UIEventHandler.java
@@ -44,9 +44,8 @@ public class UIEventHandler {
 
     public void onUserPluginListLoaded(){ serverRequester.requestUserPlugins();}
 
-    public void onPostUserPlugin(int pluginIdx,JsonConverter jsonConverter) {
-        //requestPostUserPlugin(int pluginIdx, JsonConverter jsonConverter);
-        serverRequester.requestPostUserPlugin(pluginIdx, jsonConverter);
+    public void onPostUserPlugin(int pluginIdx){
+        serverRequester.requestPostUserPlugin(pluginIdx);
     }
 
 }

--- a/app/src/main/java/org/edb/main/model/TargetProgram.java
+++ b/app/src/main/java/org/edb/main/model/TargetProgram.java
@@ -16,4 +16,12 @@ public class TargetProgram {
                 ", targetPath='" + targetPath + '\'' +
                 '}';
     }
+
+    public String getTargetName() {
+        return targetName;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
 }

--- a/app/src/main/java/org/edb/main/model/TargetWebsite.java
+++ b/app/src/main/java/org/edb/main/model/TargetWebsite.java
@@ -2,7 +2,19 @@ package org.edb.main.model;
 
 public class TargetWebsite {
     private String targetURL;
+
+    public String getTargetURL() {
+        return targetURL;
+    }
+
     public TargetWebsite(String targetURL) {
         this.targetURL = targetURL;
+    }
+
+    @Override
+    public String toString() {
+        return "TargetWebsite{" +
+                "targetURL='" + targetURL + '\'' +
+                '}';
     }
 }

--- a/app/src/main/java/org/edb/main/network/JsonConverter.java
+++ b/app/src/main/java/org/edb/main/network/JsonConverter.java
@@ -40,7 +40,7 @@ public class JsonConverter {
 //{"object":{"object1":"Chrome","object2":"game.exe"},"inactivateCondition":{"condition1":"인강5개보기","condition2":"6시간동안인터넷금지"}}
 
     //{"TargetProgram":{"targetName1" : "targetPath1", "targetName2" : "targetPath2"}, "TargetWebsites":["targetURL1", "targetURL2"],
-    //    "Config1" : {"configAttribute1" : "1", "configAttribute2" : ["arrayElement1", "arrayElement2"]}}
+    //    "Config1" : {"configAttribute1" : "1", "configAttribute2" : "[arrayElement1, arrayElement2]"}}
     public void setConfiguration(String configuration) {
 
         jsonObj = (JsonObject) jsonParser.parse(configuration);

--- a/app/src/main/java/org/edb/main/network/JsonConverter.java
+++ b/app/src/main/java/org/edb/main/network/JsonConverter.java
@@ -37,18 +37,24 @@ public class JsonConverter {
         configJsonObject = new JsonObject();
     }
 
+//{"object":{"object1":"Chrome","object2":"game.exe"},"inactivateCondition":{"condition1":"인강5개보기","condition2":"6시간동안인터넷금지"}}
 
+    //{"TargetProgram":{"targetName1" : "targetPath1", "targetName2" : "targetPath2"}, "TargetWebsites":["targetURL1", "targetURL2"],
+    //    "Config1" : {"configAttribute1" : "1", "configAttribute2" : ["arrayElement1", "arrayElement2"]}}
     public void setConfiguration(String configuration) {
 
         jsonObj = (JsonObject) jsonParser.parse(configuration);
 
+//        Key : TargetProgram, TargetWebsite, Config1
+//        반복이 필요했나? 재귀만으로 충분히 해결 가능할듯?
         for (String key : jsonObj.keySet()) {
             convert(jsonObj, key);
         }
 
     }
 
-
+//      전체 object를 통채로 전달, key = Config1
+//    element 단위로 구분한다.
     private void convert(JsonObject jsonObject, String keyName) {
         Iterator<Map.Entry<String, JsonElement>> iterator
                 = jsonObject.entrySet().iterator();

--- a/app/src/main/java/org/edb/main/network/RestAPIRequester.java
+++ b/app/src/main/java/org/edb/main/network/RestAPIRequester.java
@@ -329,9 +329,4 @@ public class RestAPIRequester  implements ServerRequester {
         System.out.println(jsonObject.toString());
         return jsonObject;
     }
-
-    public void requestPostUserPlugin(int pluginIdx,JsonConverter jsonConverter) {
-
-
-    }
 }

--- a/app/src/main/java/org/edb/main/network/TempJsonConverter.java
+++ b/app/src/main/java/org/edb/main/network/TempJsonConverter.java
@@ -1,12 +1,16 @@
 package org.edb.main.network;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.edb.main.PluginConfigConverter;
+import org.edb.main.model.TargetProgram;
+import org.edb.main.model.TargetWebsite;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Map;
 
 public class TempJsonConverter extends PluginConfigConverter {
@@ -14,12 +18,12 @@ public class TempJsonConverter extends PluginConfigConverter {
     private JsonObject jsonObjectForPost;
 
     public JsonObject getJsonObjectForPost(){
-        convert();
+        convertForPost();
         return jsonObjectForPost;
     }
 
     @Override
-    protected void convert() {
+    protected void convertForPost() {
         jsonObjectForPost = new JsonObject();
 
         SimpleDateFormat fm = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -38,12 +42,84 @@ public class TempJsonConverter extends PluginConfigConverter {
     }
 
     @Override
-    public void convertStrConfigToMap(String configuration) {
+    public void convertStrConfigs(String configuration) {
         JsonObject jsonObject = (JsonObject)new JsonParser().parse(configuration);
 
-        for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-            pluginConfigs.put(entry.getKey(),entry.getValue().toString());
+        Iterator<Map.Entry<String, JsonElement>> iterator
+                = jsonObject.entrySet().iterator();
+        Map.Entry<String, JsonElement> entry;
+
+        while(iterator.hasNext()){
+            entry=iterator.next();
+            switch(entry.getKey()) {
+                case "TargetProgram" :
+                    extractTargetProgramsFromJson((JsonObject)entry.getValue());
+                    break;
+                case "TargetWebiste" :
+                    extractTargetWebsitesFromJson((JsonObject)entry.getValue());
+                    break;
+                default:
+                    extractSpecificConfigsFromJson();
+            }
         }
+    }
+
+    private void extractTargetProgramsFromJson(JsonObject targetProgramJsons) {
+        Iterator<Map.Entry<String, JsonElement>> iterator
+                = targetProgramJsons.entrySet().iterator();
+        Map.Entry<String, JsonElement> entry;
+
+        while(iterator.hasNext()){
+            entry = iterator.next();
+            String targetPath = removeDobuleQuotesFromString(entry.getValue().toString());
+
+            TargetProgram tempTargetProgram = new TargetProgram(entry.getKey(),targetPath);
+            targetPrograms.put(entry.getKey(),tempTargetProgram);
+        }
+    }
+
+    private void extractTargetWebsitesFromJson(JsonObject targetWebsiteJsons) {
+        JsonArray targetWebsiteArray = targetWebsiteJsons.getAsJsonArray();
+
+        for (int i = 0; i < targetWebsiteArray.size(); i++) {
+            String targetURL = removeDobuleQuotesFromString(targetWebsiteArray.get(i).toString());
+            TargetWebsite tempTargetWebsite = new TargetWebsite(targetURL);
+            targetWebsites.put(targetURL,tempTargetWebsite);
+        }
+
+    }
+
+    private String removeDobuleQuotesFromString(String str){
+        return str.substring(1,str.length()-1);
+    }
+
+    private void extractSpecificConfigsFromJson() {
+
+    }
+
+
+//    TODO setTargetPrograms
+    @Override
+    public void setTargetPrograms(Map<String, TargetProgram> targetPrograms) {
+
+    }
+
+//    TODO setTargetWebsites
+    @Override
+    public void setTargetWebsites(Map<String, TargetWebsite> targetWebsites) {
+
+    }
+
+//    TODO getTargetPrograms
+    @Override
+    public Map<String, TargetProgram> getTargetPrograms() {
+        return null;
+    }
+
+//    TODO getTargetWebsites
+    @Override
+    public Map<String, TargetWebsite> getTargetWebsites() {
+        return null;
     }
 
     private String convertConfigs(){

--- a/app/src/test/java/org/edb/main/JsonConvertTest.java
+++ b/app/src/test/java/org/edb/main/JsonConvertTest.java
@@ -5,44 +5,46 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.edb.main.network.TempJsonConverter;
+import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 public class JsonConvertTest {
-    public static void main(String[] args) {
-        String configuration = "{\"TargetProgram\":{\"targetName1\" : \"targetPath1\", \"targetName2\" : \"targetPath2\"}, \"TargetWebsites\":[\"targetURL1\", \"targetURL2\"],\"Config1\" : {\"configAttribute1\" : \"1\", \"configAttribute2\" : [\"arrayElement1\", \"arrayElement2\"]}}";
+//    public static void main(String[] args) {
+//
+//        convertConfigsForPostTest();
+//
+//    }
 
-//        String configuration = "{\"TargetProgram\":{}, \"TargetWebsites\":[\"targetURL1\", \"targetURL2\"],\"Config1\" : {\"configAttribute1\" : \"1\", \"configAttribute2\" : [\"arrayElement1\", \"arrayElement2\"]}}";
+    @Test
+    public void convertConfigsForPostTest(){
+        Map<String,Map<String,String>> pluginConfigs= new HashMap<String,Map<String,String>>();
 
-        JsonParser jsonParser = new JsonParser();
-        JsonObject jsonObject = (JsonObject)jsonParser.parse(configuration);
-        for (String key :
-                jsonObject.keySet()) {
-            System.out.println(key);
-        }
+        Map<String,String> config1 = new HashMap<String,String>();
+        config1.put("attribute1","1");
+        config1.put("attribute2","5");
 
-        Iterator<Map.Entry<String, JsonElement>> iterator
-                = jsonObject.entrySet().iterator();
-        Map.Entry<String, JsonElement> entry;
+        Map<String,String> config2 = new HashMap<String,String>();
+        config2.put("attribute3","[element1,element2]");
 
+        pluginConfigs.put("config1",config1);
+        pluginConfigs.put("config2",config2);
 
-        while(iterator.hasNext()){
-            entry=iterator.next();
-            switch(entry.getKey()) {
-                case "TargetProgram" :
-//                    만약 비어있으면 어떻게 처리되나?
-                    System.out.println(((JsonObject)entry.getValue()).toString());
-                    break;
-                case "TargetWebiste" :
-//                    extractTargetWebsitesFromJson();
-                    break;
-                default:
-//                    extractSpecificConfigsFromJson();
+        JsonObject configJsonObject = new JsonObject();
+
+        for(Map.Entry<String,Map<String,String>> singleConfigMap : pluginConfigs.entrySet()){
+            JsonObject attributesJsonObject = new JsonObject();
+            for (Map.Entry<String,String> singleAttribute : singleConfigMap.getValue().entrySet()) {
+
+                attributesJsonObject.addProperty(singleAttribute.getKey(),singleAttribute.getValue());
             }
+
+            System.out.println(attributesJsonObject.toString());
+            configJsonObject.add(singleConfigMap.getKey(),attributesJsonObject);
         }
 
-        TempJsonConverter jsonConverter = new TempJsonConverter();
-        jsonConverter.convertStrConfigs(configuration);
+        System.out.println(configJsonObject.toString());
     }
 }

--- a/app/src/test/java/org/edb/main/JsonConvertTest.java
+++ b/app/src/test/java/org/edb/main/JsonConvertTest.java
@@ -1,0 +1,48 @@
+package org.edb.main;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.edb.main.network.TempJsonConverter;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class JsonConvertTest {
+    public static void main(String[] args) {
+        String configuration = "{\"TargetProgram\":{\"targetName1\" : \"targetPath1\", \"targetName2\" : \"targetPath2\"}, \"TargetWebsites\":[\"targetURL1\", \"targetURL2\"],\"Config1\" : {\"configAttribute1\" : \"1\", \"configAttribute2\" : [\"arrayElement1\", \"arrayElement2\"]}}";
+
+//        String configuration = "{\"TargetProgram\":{}, \"TargetWebsites\":[\"targetURL1\", \"targetURL2\"],\"Config1\" : {\"configAttribute1\" : \"1\", \"configAttribute2\" : [\"arrayElement1\", \"arrayElement2\"]}}";
+
+        JsonParser jsonParser = new JsonParser();
+        JsonObject jsonObject = (JsonObject)jsonParser.parse(configuration);
+        for (String key :
+                jsonObject.keySet()) {
+            System.out.println(key);
+        }
+
+        Iterator<Map.Entry<String, JsonElement>> iterator
+                = jsonObject.entrySet().iterator();
+        Map.Entry<String, JsonElement> entry;
+
+
+        while(iterator.hasNext()){
+            entry=iterator.next();
+            switch(entry.getKey()) {
+                case "TargetProgram" :
+//                    만약 비어있으면 어떻게 처리되나?
+                    System.out.println(((JsonObject)entry.getValue()).toString());
+                    break;
+                case "TargetWebiste" :
+//                    extractTargetWebsitesFromJson();
+                    break;
+                default:
+//                    extractSpecificConfigsFromJson();
+            }
+        }
+
+        TempJsonConverter jsonConverter = new TempJsonConverter();
+        jsonConverter.convertStrConfigs(configuration);
+    }
+}

--- a/app/src/test/java/org/edb/main/TestEDBPlugin.java
+++ b/app/src/test/java/org/edb/main/TestEDBPlugin.java
@@ -1,14 +1,21 @@
 package org.edb.main;
 
+import org.edb.main.model.TargetProgram;
+import org.edb.main.model.TargetWebsite;
+
 import java.util.HashMap;
 
 public class TestEDBPlugin extends EDBPlugin {
 
+    private static final int pluginIdx=1;
 
     public TestEDBPlugin(){
         pluginConfigs = new HashMap<String,PluginConfig>();
+        targetPrograms = new HashMap<String, TargetProgram>();
+        targetWebsites = new HashMap<String, TargetWebsite>();
         TestPluginConfig testPluginConfig = new TestPluginConfig();
         pluginConfigs.put("TestPluginConfig", testPluginConfig);
+
     }
 
 
@@ -30,5 +37,10 @@ public class TestEDBPlugin extends EDBPlugin {
     @Override
     public void checkForLogics() {
 
+    }
+
+    @Override
+    public int getPluginIdx() {
+        return pluginIdx;
     }
 }

--- a/app/src/test/java/org/edb/main/TestPluginConfig.java
+++ b/app/src/test/java/org/edb/main/TestPluginConfig.java
@@ -1,6 +1,7 @@
 package org.edb.main;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class TestPluginConfig extends PluginConfig {
     private int tempConfigInt;
@@ -24,7 +25,7 @@ public class TestPluginConfig extends PluginConfig {
 
 //  TODO 테스트용 말고 제대로된 decode 작성 필요
     @Override
-    public void decode(String decodeConfig) {
+    public void decode(Map<String, String> decodeConfig) {
         System.out.println("decode with some Logics");
         System.out.println(decodeConfig);
     }
@@ -38,6 +39,6 @@ public class TestPluginConfig extends PluginConfig {
     public void extractConfig(PluginConfigConverter pluginConfigConverter) {
         StringBuffer stringBuffer = new StringBuffer();
         stringBuffer.append("tempConfigInt : 3, tempConfigStr : tempStr");
-        pluginConfigConverter.addSingleConfig("TestPluginConfig",stringBuffer.toString());
+//        pluginConfigConverter.addSingleConfig();
     }
 }

--- a/app/src/test/java/org/edb/main/TestPluginConfig.java
+++ b/app/src/test/java/org/edb/main/TestPluginConfig.java
@@ -1,6 +1,8 @@
 package org.edb.main;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 public class TestPluginConfig extends PluginConfig {
@@ -12,22 +14,39 @@ public class TestPluginConfig extends PluginConfig {
         tempConfigList = new ArrayList<String>();
     }
 
-//    TODO 하드코딩 컨피그에서 변경필요
+
     @Override
-    public void addSingleConfig(String singleConfig) {
-        if(singleConfig.startsWith("tempConfigInt : ")){
-            tempConfigInt=3;
+    public void addSingleConfig(String attributeName, String attributeValue) {
+        switch(attributeName){
+            case "tempConfigInt":
+                tempConfigInt = Integer.parseInt(attributeValue);
+                break;
+            case "tempConfigStr":
+                tempConfigStr = attributeValue;
+                break;
+            case"tempConfigList":
+                addToTempConfigList(attributeValue);
+                break;
+            default:
+                System.out.println("error");
         }
-        if(singleConfig.startsWith("tempConfigStr: ")){
-            tempConfigStr = "tempStr";
-        }
+
     }
 
-//  TODO 테스트용 말고 제대로된 decode 작성 필요
+//    TODO arrayList가 원시자료형을 담지 않을 가능성 고려 필요.(개별 플러그인 개발자가 해야할 역할)
+
+    private void addToTempConfigList(String attributeValue) {
+        ArrayList<String> tempList = new ArrayList<String>(Arrays.asList(attributeValue.split(",")));
+        tempConfigList.addAll(tempList);
+    }
+
     @Override
-    public void decode(Map<String, String> decodeConfig) {
-        System.out.println("decode with some Logics");
-        System.out.println(decodeConfig);
+    public void decodeFromMap(Map<String, String> decodeConfig) {
+
+        tempConfigInt = Integer.parseInt(decodeConfig.get("tempConfigInt"));
+        tempConfigStr = decodeConfig.get("tempConfigStr");
+
+        tempConfigList = new ArrayList<String>(Arrays.asList(decodeConfig.get("tempConfigList").split(",")));
     }
 
     @Override
@@ -37,8 +56,22 @@ public class TestPluginConfig extends PluginConfig {
 
     @Override
     public void extractConfig(PluginConfigConverter pluginConfigConverter) {
-        StringBuffer stringBuffer = new StringBuffer();
-        stringBuffer.append("tempConfigInt : 3, tempConfigStr : tempStr");
-//        pluginConfigConverter.addSingleConfig();
+        Map<String,String> attributesMap = new HashMap<String,String>();
+
+        attributesMap.put("tempConfigInt",Integer.toString(tempConfigInt));
+        attributesMap.put("tempConfigStr",tempConfigStr);
+
+
+        pluginConfigConverter.addSingleConfig("TestPluginConfig", attributesMap);
+    }
+
+    private String convertListToSingleStr(){
+        StringBuffer sbr = new StringBuffer();
+
+        for (String str : tempConfigList) {
+            sbr.append(str);
+        }
+
+        return sbr.toString();
     }
 }

--- a/app/src/test/java/org/edb/main/network/RestAPIRequesterTest.java
+++ b/app/src/test/java/org/edb/main/network/RestAPIRequesterTest.java
@@ -25,44 +25,45 @@ public class RestAPIRequesterTest {
 
     private static RestAPIRequester restAPIRequester;
 
-    public static void main(String[] args) {
-        tempPostPluginDetail();
-
-        //Mockito를 이용한 callback test
-//        ServerResponseHandler serverResponseHandler = mock(ServerResponseHandler.class);
-////
-////
-////        //callback boolean successful, String id
-////        doAnswer(new Answer() {
-////            @Override
-////            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-////                java.lang.Object[] args = invocationOnMock.getArguments();
-////                System.out.print("\nargs test33\n");
-////                System.out.print(args);
-////                System.out.print("\ntoken mock test33\n");
-////                System.out.print(User.getUser().getToken());//token
-////
-////                //잠금정책목록
-//////                requestUserPlugins();
-////
-////                // 2. 잠금정책등록 선택시 추가가능한 잠금정책목록보여주기
-////                //requestAvailablePlugins();
-////
-////                //3.잠금정책목록에서 특정 잠금 정책 클릭 시 잠금정책설정 불러오기
+//    public static void main(String[] args) {
+//        tempPostPluginDetail();
+//
+//        //Mockito를 이용한 callback test
+////        ServerResponseHandler serverResponseHandler = mock(ServerResponseHandler.class);
+//////
+//////
+//////        //callback boolean successful, String id
+//////        doAnswer(new Answer() {
+//////            @Override
+//////            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+//////                java.lang.Object[] args = invocationOnMock.getArguments();
+//////                System.out.print("\nargs test33\n");
+//////                System.out.print(args);
+//////                System.out.print("\ntoken mock test33\n");
+//////                System.out.print(User.getUser().getToken());//token
+//////
+//////                //잠금정책목록
+////////                requestUserPlugins();
+//////
+//////                // 2. 잠금정책등록 선택시 추가가능한 잠금정책목록보여주기
+//////                //requestAvailablePlugins();
+//////
+//////                //3.잠금정책목록에서 특정 잠금 정책 클릭 시 잠금정책설정 불러오기
+////////                requestUserDetailPlugin();
+////////'{"configuration":{"object":{"object_idx1":"Game.exe","object_idx2":"Chrome"}\n,"time":{"start_time":"09:20","end_time":"15:00"}}}'
+//////                // 4. 잠금정책목록에서 특정 잠금 정책 화면에서 잠금정책설정 저장
+//////                requestPostPluginDetail();
+//////
+//////
 //////                requestUserDetailPlugin();
-//////'{"configuration":{"object":{"object_idx1":"Game.exe","object_idx2":"Chrome"}\n,"time":{"start_time":"09:20","end_time":"15:00"}}}'
-////                // 4. 잠금정책목록에서 특정 잠금 정책 화면에서 잠금정책설정 저장
-////                requestPostPluginDetail();
-////
-////
-////                requestUserDetailPlugin();
-////
-////                return null;
-////            }
-////        }).when(serverResponseHandler).handleLoginResponse(anyBoolean(), anyString(),anyString());
-    }
+//////
+//////                return null;
+//////            }
+//////        }).when(serverResponseHandler).handleLoginResponse(anyBoolean(), anyString(),anyString());
+//    }
 
-    public static void requestLoginTest(){
+    @Test
+    public void requestLoginTest(){
         /*
             response의 결과들의 이름을 ArrayList에 담는다.
             아무렇게나 지정해도 무관하지만, response 개수와는 일치시켜야함
@@ -96,17 +97,17 @@ public class RestAPIRequesterTest {
     }
 
     // 1. 잠금정책목록
-    public static void requestUserPlugins() {
+    public void requestUserPlugins() {
         restAPIRequester.requestUserPlugins();
     }
 
     // 2. 잠금정책등록 선택시 추가가능한 잠금정책목록보여주기
-    public static void requestAvailablePlugins(){ restAPIRequester.requestAvailablePlugins(); }
+    public void requestAvailablePlugins(){ restAPIRequester.requestAvailablePlugins(); }
 
     // 3. 잠금정책목록에서 특정 잠금 정책 클릭 시 잠금정책설정 불러오기
-    public static void requestUserDetailPlugin(){restAPIRequester.requestPluginDetails(1);}
+    public void requestUserDetailPlugin(){restAPIRequester.requestPluginDetails(1);}
     // 4. 잠금정책목록에서 특정 잠금 정책 화면에서 잠 금정책설정 저장
-    public static void requestPostPluginDetail(){
+    public void requestPostPluginDetail(){
 
 
         Time time = new Time("2019-11-19 12:00","2019-11-29 18:00");
@@ -142,7 +143,7 @@ public class RestAPIRequesterTest {
     }
 
     @Test
-    public static void tempRequestPluginDetail(){
+    public void tempRequestPluginDetail(){
 
         RestAPITestAPI.loginFotTest("jooha208","123");
 
@@ -151,15 +152,15 @@ public class RestAPIRequesterTest {
     }
 
     @Test
-    public static void tempPostPluginDetail(){
+    public void tempPostPluginDetail(){
         RestAPITestAPI.loginFotTest("jooha208","123");
         TestEDBPlugin testEDBPlugin = new TestEDBPlugin();
-//        TODO TargetProgramConfig 정의 필요
-//        TODO TargetWebsiteConfig 정의 필요
-//        testEDBPlugin.addTargetProgram(new TargetProgram("chrome","chrome.exe"));
-//        testEDBPlugin.addTargetWebsite(new TargetWebsite("www.naver.com"));
-        testEDBPlugin.applySingleConfig("TestPluginConfig","tempConfigInt : 3");
-        testEDBPlugin.applySingleConfig("TestPluginConfig","tempConfigStr : tempStr");
+
+        testEDBPlugin.addTargetProgram(new TargetProgram("chrome","C:\\chrome"));
+        testEDBPlugin.addTargetWebsite(new TargetWebsite("www.naver.com"));
+
+        testEDBPlugin.applySingleConfig("TestPluginConfig","tempConfigInt","3");
+        testEDBPlugin.applySingleConfig("TestPluginConfig","tempConfigStr", "tempStr");
         testEDBPlugin.applySchedule(new Date(), new Date());
 
         TempJsonConverter tempJsonConverter= new TempJsonConverter();
@@ -176,8 +177,6 @@ public class RestAPIRequesterTest {
         JsonObject jsonObejct = tempJsonConverter.getJsonObjectForPost();
 
         System.out.println(jsonObejct.toString());
-//        TODO slash가 나중에 decode할때 걸림돌이 될 수도 있음
-//        {"start_time":"2019-12-01 11:45:51","end_time":"2019-12-01 11:45:51","configuration":"{\"TestPluginConfig\":\"tempConfigInt : 3, tempConfigStr : tempStr\"}"}
 
 //        restAPIRequester1.postUserPluginWithJsonObject(1, tempJsonConverter.getJsonObjectForPost());
     }


### PR DESCRIPTION
#25, #29에서 먼저 작성되어있었던 JsonConverter의 코드를 많이 참고하여 EDBPlugin에 visitor 패턴을 적용할 수 있는 TempJsonConverter를 정의

타겟웹사이트, 프로그램은 PluginConfig를 상속하는게 아니라 EDBPlugin의 attribute로 정의를 변경함으로서 요구되는 수정사항들을 적용

현재 샘플 플러그인은 테스트용으로 아무 의미없는 값만 넣어두었고, 일반적인 PluginConfigUI만 정의되고, Plugin마다 개별적인 pluginConfigUI가 정의되어있지 않으므로 PluginConfigUI에 대한 전반적인 테스트가 어려움

다음은 실질적으로 함께 배포해도 될만한 가장 기본적인 형태의 잠금 정책을 구체적으로 만들고자 함
플러그인 로직, 액션 통합과 개별적 pluginConfigUI의 정의는 기존 config에 메소드형태로 추가하면 되고 일부 renaming만 거치면 되므로 이 작업과 함께 진행할 예정